### PR TITLE
Increase status update interval to 30 seconds

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -27,7 +27,7 @@ var WS_SECRET = process.env.WS_SECRET || "eth-net-stats-has-a-secret";
 
 var PENDING_WORKS = true;
 var MAX_BLOCKS_HISTORY = 40;
-var UPDATE_INTERVAL = 5000;
+var UPDATE_INTERVAL = 30000;
 var PING_INTERVAL = 3000;
 var MINERS_LIMIT = 5;
 var MAX_HISTORY_UPDATE = 50;


### PR DESCRIPTION
Most of the relevant information is sent with the block anyway, so a slower status update will reduce the node load and still give good enough insight.