### PR TITLE
Build and deploy (pre-)release images in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,54 +9,151 @@ executors:
 # define some common commands
 # see https://circleci.com/docs/2.0/configuration-reference/#commands-requires-version-21
 commands:
-  build-docker-image:
-    parameters:
-      local-name:
-        type: string
-    steps:
-      - run:
-          name: Build docker image
-          command: |
-            docker build . -t << parameters.local-name >>
   upload-docker-image:
-    parameters:
-      local-name:
-        type: string
-      remote-name:
-        type: string
-      tag:
-        type: string
     steps:
+      - setup_remote_docker
+      - attach_workspace:
+          at: "~"
+      - run:
+          name: Load docker image
+          command: |
+            du -hc ~/images/*
+            docker load --input ~/images/$LOCAL_IMAGE.tar
+            docker image ls
+      - run:
+          name: Login to dockerhub
+          command: |
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
       - run:
           name: Upload docker image
           command: |
-            tag=$(echo << parameters.tag >> | sed -e 's=/=-=')
-            remote=<< parameters.remote-name >>:$tag
-            docker tag << parameters.local-name >> $remote
-            docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-            docker push $remote
+            echo "Uploading to $DOCKER_REPO"
+            CLEAN_BRANCH_NAME=${CIRCLE_BRANCH##*/}
+            # e.g. transforms 'netstats-client/pre-release' to 'pre-release'
+            docker tag $LOCAL_IMAGE $DOCKER_REPO:$CLEAN_BRANCH_NAME$CIRCLE_BUILD_NUM
+            docker push $DOCKER_REPO:$CLEAN_BRANCH_NAME$CIRCLE_BUILD_NUM
+            docker tag $LOCAL_IMAGE $DOCKER_REPO:$CLEAN_BRANCH_NAME
+            docker push $DOCKER_REPO:$CLEAN_BRANCH_NAME
 
 jobs:
-  build-and-upload:
+  build-image:
     executor: ubuntu-builder
+    environment:
+      LOCAL_IMAGE: netstats-client
     steps:
       - setup_remote_docker
       - checkout
-      - build-docker-image:
-          local-name: "netstats-client"
-      - upload-docker-image:
-          local-name: "netstats-client"
-          remote-name: "trustlines/netstats-client"
-          tag: "$CIRCLE_BRANCH$CIRCLE_BUILD_NUM"
-      - upload-docker-image:
-          local-name: "netstats-client"
-          remote-name: "trustlines/netstats-client"
-          tag: "$CIRCLE_BRANCH"
+      - run:
+          name: Build docker image
+          command: |
+            docker build . -t $LOCAL_IMAGE
+      - run:
+          name: Save docker image
+          command: |
+            mkdir -p ~/images
+            docker save --output ~/images/$LOCAL_IMAGE.tar $LOCAL_IMAGE
+            du -hc ~/images
+      - persist_to_workspace:
+          root: "~"
+          paths:
+            - images
+
+  deploy-image:
+    executor: ubuntu-builder
+    environment:
+      LOCAL_IMAGE: netstats-client
+    working_directory: ~/repo
+    steps:
+      - run:
+          name: set DOCKER_REPO
+          command: |
+            echo ': \"${DOCKER_REPO:=trustlines/netstats-client}\"' >> ${BASH_ENV}
+          # this allows us to set DOCKER_REPO from circleci when building in a
+          # fork. makes testing easier.
+      - upload-docker-image
+
+  compare-image:
+    executor: ubuntu-builder
+    environment:
+      LOCAL_IMAGE: netstats-client
+    working_directory: ~/repo
+    steps:
+      - setup_remote_docker
+      - checkout
+      - attach_workspace:
+          at: "~"
+      - run:
+          name: Load docker image
+          command: |
+            du -hc ~/images/*
+            docker load --input ~/images/$LOCAL_IMAGE.tar
+            docker image ls
+      - run:
+          name: Fetch latest pre-release
+          command: |
+            docker pull trustlines/netstats-client:pre-release
+      - run:
+          name: Compute image tree summaries
+          command: |
+            .circleci/show-docker-tree trustlines/netstats-client:pre-release >/tmp/tree-pre-release
+            .circleci/show-docker-tree $LOCAL_IMAGE >/tmp/tree-local
+      - run:
+          name: Compare image tree summaries
+          command: |
+            diff -s /tmp/tree-pre-release /tmp/tree-local || true
+
+  deploy-release-image:
+    executor: ubuntu-builder
+    environment:
+      LOCAL_IMAGE: netstats-client
+    working_directory: ~/repo
+    steps:
+      - run:
+          name: set DOCKER_REPO
+          command: |
+            echo ': \"${DOCKER_REPO:=trustlines/netstats-client}\"' >> ${BASH_ENV}
+          # this allows us to set DOCKER_REPO from circleci when building in a
+          # fork. makes testing easier.
+      - upload-docker-image
+      - run:
+          name: Upload latest image
+          command: |
+            docker tag $LOCAL_IMAGE $DOCKER_REPO:latest
+            docker push $DOCKER_REPO:latest
 
 
 workflows:
   version: 2
   default:
     jobs:
-      - build-and-upload:
+      - build-image
+      - deploy-image:
+          filters:
+            branches:
+              only:
+                - master
+                - pre-release
           context: docker-credentials
+      - compare-image:
+          filters:
+            branches:
+              only:
+                - release
+          requires:
+            - build-image
+      - approve-release:
+          type: approval
+          filters:
+            branches:
+              only:
+                - release
+          requires:
+            - build-image
+      - deploy-release-image:
+          filters:
+            branches:
+              only:
+                - release
+          requires:
+            - approve-release
+          context: docker-release-credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
   build-image:
     executor: ubuntu-builder
     environment:
-      LOCAL_IMAGE: netstats-client
+      LOCAL_IMAGE: netstats-client-next
     steps:
       - setup_remote_docker
       - checkout
@@ -61,13 +61,13 @@ jobs:
   deploy-image:
     executor: ubuntu-builder
     environment:
-      LOCAL_IMAGE: netstats-client
+      LOCAL_IMAGE: netstats-client-next
     working_directory: ~/repo
     steps:
       - run:
           name: set DOCKER_REPO
           command: |
-            echo ': \"${DOCKER_REPO:=trustlines/netstats-client}\"' >> ${BASH_ENV}
+            echo ': \"${DOCKER_REPO:=trustlines/netstats-client-next}\"' >> ${BASH_ENV}
           # this allows us to set DOCKER_REPO from circleci when building in a
           # fork. makes testing easier.
       - upload-docker-image
@@ -75,7 +75,7 @@ jobs:
   compare-image:
     executor: ubuntu-builder
     environment:
-      LOCAL_IMAGE: netstats-client
+      LOCAL_IMAGE: netstats-client-next
     working_directory: ~/repo
     steps:
       - setup_remote_docker
@@ -91,11 +91,11 @@ jobs:
       - run:
           name: Fetch latest pre-release
           command: |
-            docker pull trustlines/netstats-client:pre-release
+            docker pull trustlines/netstats-client-next:pre-release
       - run:
           name: Compute image tree summaries
           command: |
-            .circleci/show-docker-tree trustlines/netstats-client:pre-release >/tmp/tree-pre-release
+            .circleci/show-docker-tree trustlines/netstats-client-next:pre-release >/tmp/tree-pre-release
             .circleci/show-docker-tree $LOCAL_IMAGE >/tmp/tree-local
       - run:
           name: Compare image tree summaries
@@ -105,7 +105,7 @@ jobs:
   deploy-release-image:
     executor: ubuntu-builder
     environment:
-      LOCAL_IMAGE: netstats-client
+      LOCAL_IMAGE: netstats-client-next
     working_directory: ~/repo
     steps:
       - run:

--- a/.circleci/show-docker-tree
+++ b/.circleci/show-docker-tree
@@ -1,0 +1,47 @@
+#! /usr/bin/perl -w
+
+# This program can be used to show the contents of a docker image The output of
+# two invocations of this program can be compared and if it doesn't differ, the
+# image will be the same (file modification times may differ however)
+
+# Example how to call it:
+#
+# show-docker-tree ubuntu:18.04
+
+use strict;
+use Fcntl ':mode';
+use POSIX;
+
+# When called with an argument, call docker .... perl -, with input redirected
+# from the script itself in order to run the script inside the docker container
+if ($#ARGV == 0) {
+    my $fd = POSIX::open("$0", O_RDONLY) or die "could not open perl script";
+    POSIX::dup2($fd, 0) or die "could not dup2";
+    POSIX::close($fd);
+    exec "docker", "run", "--rm", "-i", "--entrypoint", "", $ARGV[0], "perl", "-" or die "could not exec"
+}
+
+# These files are modified by docker, ignore them
+my %ignore_files = (
+    "/etc/hostname" => 1,
+    "/etc/hosts" => 1,
+    );
+
+my @files = sort split /\n/, `find / -xdev` or die "could not run find";
+foreach my $filename (@files) {
+    my ($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size,
+        $atime,$mtime,$ctime,$blksize,$blocks)
+        = lstat($filename) or die "could not stat $filename";
+    my $perm = sprintf("%o", S_IMODE($mode));
+    my $type = S_IFMT($mode);
+    my $digest = "----------------------------------------------------------------";
+    if (S_ISREG($mode)) {
+        $digest = (split / /, `sha256sum $filename`)[0];
+    }
+    my $target = "";
+    if (S_ISLNK($mode)) {
+        $target = readlink ($filename);
+    }
+
+    print("$perm\t$type\t$uid\t$gid\t$digest\t$filename\t$target\n") unless $ignore_files{$filename};
+}


### PR DESCRIPTION
Updated the CircleCI config to build and deploy release and pre-release images in the same manner the blockchain repo does for the blockchain and bridge images.

I couldn't find the task for this, but it's mentioned in the [user story](https://github.com/trustlines-network/project/issues/684#issuecomment-541646761).